### PR TITLE
Fix syntax highlighting for code snippet

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -29,7 +29,7 @@ LinuxBoot is a Linux Foundation project and as such has a [technical charter](
 
 ### Getting Started
 
-```
+```sh
 git clone https://github.com/linuxboot/linuxboot
 cd linuxboot
 make \

--- a/static/css/syntax.css
+++ b/static/css/syntax.css
@@ -1,67 +1,86 @@
-/* Background */ .chroma { background-color: #f0f3f3 }
-/* Error */ .chroma .err { color: #aa0000; background-color: #ffaaaa }
-/* LineTableTD */ .chroma .lntd { ; vertical-align: top; padding: 0; margin: 0; border: 0; }
-/* LineTable */ .chroma .lntable { ; border-spacing: 0; padding: 0; margin: 0; border: 0; width: 100%; overflow: auto; display: block; }
-/* LineHighlight */ .chroma .hl { background-color: #ffffcc; display: block; width: 100% }
-/* LineNumbersTable */ .chroma .lnt { ; margin-right: 0.4em; padding: 0 0.4em 0 0.4em; display: block; }
-/* LineNumbers */ .chroma .ln { ; margin-right: 0.4em; padding: 0 0.4em 0 0.4em; }
-/* Keyword */ .chroma .k { color: #006699; font-weight: bold }
-/* KeywordConstant */ .chroma .kc { color: #006699; font-weight: bold }
-/* KeywordDeclaration */ .chroma .kd { color: #006699; font-weight: bold }
-/* KeywordNamespace */ .chroma .kn { color: #006699; font-weight: bold }
-/* KeywordPseudo */ .chroma .kp { color: #006699 }
-/* KeywordReserved */ .chroma .kr { color: #006699; font-weight: bold }
-/* KeywordType */ .chroma .kt { color: #007788; font-weight: bold }
-/* NameAttribute */ .chroma .na { color: #330099 }
-/* NameBuiltin */ .chroma .nb { color: #336666 }
-/* NameClass */ .chroma .nc { color: #00aa88; font-weight: bold }
-/* NameConstant */ .chroma .no { color: #336600 }
-/* NameDecorator */ .chroma .nd { color: #9999ff }
-/* NameEntity */ .chroma .ni { color: #999999; font-weight: bold }
-/* NameException */ .chroma .ne { color: #cc0000; font-weight: bold }
-/* NameFunction */ .chroma .nf { color: #cc00ff }
-/* NameLabel */ .chroma .nl { color: #9999ff }
-/* NameNamespace */ .chroma .nn { color: #00ccff; font-weight: bold }
-/* NameTag */ .chroma .nt { color: #330099; font-weight: bold }
-/* NameVariable */ .chroma .nv { color: #003333 }
-/* LiteralString */ .chroma .s { color: #cc3300 }
-/* LiteralStringAffix */ .chroma .sa { color: #cc3300 }
-/* LiteralStringBacktick */ .chroma .sb { color: #cc3300 }
-/* LiteralStringChar */ .chroma .sc { color: #cc3300 }
-/* LiteralStringDelimiter */ .chroma .dl { color: #cc3300 }
-/* LiteralStringDoc */ .chroma .sd { color: #cc3300; font-style: italic }
-/* LiteralStringDouble */ .chroma .s2 { color: #cc3300 }
-/* LiteralStringEscape */ .chroma .se { color: #cc3300; font-weight: bold }
-/* LiteralStringHeredoc */ .chroma .sh { color: #cc3300 }
-/* LiteralStringInterpol */ .chroma .si { color: #aa0000 }
-/* LiteralStringOther */ .chroma .sx { color: #cc3300 }
-/* LiteralStringRegex */ .chroma .sr { color: #33aaaa }
-/* LiteralStringSingle */ .chroma .s1 { color: #cc3300 }
-/* LiteralStringSymbol */ .chroma .ss { color: #ffcc33 }
-/* LiteralNumber */ .chroma .m { color: #ff6600 }
-/* LiteralNumberBin */ .chroma .mb { color: #ff6600 }
-/* LiteralNumberFloat */ .chroma .mf { color: #ff6600 }
-/* LiteralNumberHex */ .chroma .mh { color: #ff6600 }
-/* LiteralNumberInteger */ .chroma .mi { color: #ff6600 }
-/* LiteralNumberIntegerLong */ .chroma .il { color: #ff6600 }
-/* LiteralNumberOct */ .chroma .mo { color: #ff6600 }
-/* Operator */ .chroma .o { color: #555555 }
-/* OperatorWord */ .chroma .ow { color: #000000; font-weight: bold }
-/* Comment */ .chroma .c { color: #0099ff; font-style: italic }
-/* CommentHashbang */ .chroma .ch { color: #0099ff; font-style: italic }
-/* CommentMultiline */ .chroma .cm { color: #0099ff; font-style: italic }
-/* CommentSingle */ .chroma .c1 { color: #0099ff; font-style: italic }
-/* CommentSpecial */ .chroma .cs { color: #0099ff; font-weight: bold; font-style: italic }
-/* CommentPreproc */ .chroma .cp { color: #009999 }
-/* CommentPreprocFile */ .chroma .cpf { color: #009999 }
-/* GenericDeleted */ .chroma .gd { background-color: #ffcccc }
+/* Background */ .bg { color: #c9d1d9; background-color: #0d1117; }
+/* PreWrapper */ .chroma { color: #c9d1d9; background-color: #0d1117; }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err { color: #f85149 }
+/* CodeLine */ .chroma .cl {  }
+/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: #ff7b72 }
+/* KeywordConstant */ .chroma .kc { color: #79c0ff }
+/* KeywordDeclaration */ .chroma .kd { color: #ff7b72 }
+/* KeywordNamespace */ .chroma .kn { color: #ff7b72 }
+/* KeywordPseudo */ .chroma .kp { color: #79c0ff }
+/* KeywordReserved */ .chroma .kr { color: #ff7b72 }
+/* KeywordType */ .chroma .kt { color: #ff7b72 }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na {  }
+/* NameBuiltin */ .chroma .nb {  }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: #f0883e; font-weight: bold }
+/* NameConstant */ .chroma .no { color: #79c0ff; font-weight: bold }
+/* NameDecorator */ .chroma .nd { color: #d2a8ff; font-weight: bold }
+/* NameEntity */ .chroma .ni { color: #ffa657 }
+/* NameException */ .chroma .ne { color: #f0883e; font-weight: bold }
+/* NameFunction */ .chroma .nf { color: #d2a8ff; font-weight: bold }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl { color: #79c0ff; font-weight: bold }
+/* NameNamespace */ .chroma .nn { color: #ff7b72 }
+/* NameOther */ .chroma .nx {  }
+/* NameProperty */ .chroma .py { color: #79c0ff }
+/* NameTag */ .chroma .nt { color: #7ee787 }
+/* NameVariable */ .chroma .nv { color: #79c0ff }
+/* NameVariableClass */ .chroma .vc {  }
+/* NameVariableGlobal */ .chroma .vg {  }
+/* NameVariableInstance */ .chroma .vi {  }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l { color: #a5d6ff }
+/* LiteralDate */ .chroma .ld { color: #79c0ff }
+/* LiteralString */ .chroma .s { color: #a5d6ff }
+/* LiteralStringAffix */ .chroma .sa { color: #79c0ff }
+/* LiteralStringBacktick */ .chroma .sb { color: #a5d6ff }
+/* LiteralStringChar */ .chroma .sc { color: #a5d6ff }
+/* LiteralStringDelimiter */ .chroma .dl { color: #79c0ff }
+/* LiteralStringDoc */ .chroma .sd { color: #a5d6ff }
+/* LiteralStringDouble */ .chroma .s2 { color: #a5d6ff }
+/* LiteralStringEscape */ .chroma .se { color: #79c0ff }
+/* LiteralStringHeredoc */ .chroma .sh { color: #79c0ff }
+/* LiteralStringInterpol */ .chroma .si { color: #a5d6ff }
+/* LiteralStringOther */ .chroma .sx { color: #a5d6ff }
+/* LiteralStringRegex */ .chroma .sr { color: #79c0ff }
+/* LiteralStringSingle */ .chroma .s1 { color: #a5d6ff }
+/* LiteralStringSymbol */ .chroma .ss { color: #a5d6ff }
+/* LiteralNumber */ .chroma .m { color: #a5d6ff }
+/* LiteralNumberBin */ .chroma .mb { color: #a5d6ff }
+/* LiteralNumberFloat */ .chroma .mf { color: #a5d6ff }
+/* LiteralNumberHex */ .chroma .mh { color: #a5d6ff }
+/* LiteralNumberInteger */ .chroma .mi { color: #a5d6ff }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #a5d6ff }
+/* LiteralNumberOct */ .chroma .mo { color: #a5d6ff }
+/* Operator */ .chroma .o { color: #ff7b72; font-weight: bold }
+/* OperatorWord */ .chroma .ow { color: #ff7b72; font-weight: bold }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #8b949e; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #8b949e; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #8b949e; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #8b949e; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #8b949e; font-weight: bold; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: #8b949e; font-weight: bold; font-style: italic }
+/* CommentPreprocFile */ .chroma .cpf { color: #8b949e; font-weight: bold; font-style: italic }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color: #ffa198; background-color: #490202 }
 /* GenericEmph */ .chroma .ge { font-style: italic }
-/* GenericError */ .chroma .gr { color: #ff0000 }
-/* GenericHeading */ .chroma .gh { color: #003300; font-weight: bold }
-/* GenericInserted */ .chroma .gi { background-color: #ccffcc }
-/* GenericOutput */ .chroma .go { color: #aaaaaa }
-/* GenericPrompt */ .chroma .gp { color: #000099; font-weight: bold }
+/* GenericError */ .chroma .gr { color: #ffa198 }
+/* GenericHeading */ .chroma .gh { color: #79c0ff; font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #56d364; background-color: #0f5323 }
+/* GenericOutput */ .chroma .go { color: #8b949e }
+/* GenericPrompt */ .chroma .gp { color: #8b949e }
 /* GenericStrong */ .chroma .gs { font-weight: bold }
-/* GenericSubheading */ .chroma .gu { color: #003300; font-weight: bold }
-/* GenericTraceback */ .chroma .gt { color: #99cc66 }
-/* TextWhitespace */ .chroma .w { color: #bbbbbb }
+/* GenericSubheading */ .chroma .gu { color: #79c0ff }
+/* GenericTraceback */ .chroma .gt { color: #ff7b72 }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #6e7681 }


### PR DESCRIPTION
This sets the syntax for `content/_index` to be shell input.
In dark mode, it was barely readable, light grey on nearly white.

We pick the github-dark style for best readability on the dark grey
background.

CSS generated via:
```sh
hugo gen chromastyles --style=github-dark > static/css/syntax.css
```

See also:
https://github.com/halogenica/beautifulhugo#syntax-highlighting

Signed-off-by: Daniel Maslowski <info@orangecms.org>
