### PR TITLE
CI: upgrade to Ubuntu 24.04

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod


### PR DESCRIPTION
Job runs are currently failing due to the deprecation/brownout of 20.04.

Signed-off-by: Daniel Maslowski <info@orangecms.org>
