### PR TITLE
fix style for lengthy links

### DIFF
--- a/layouts/partials/head_custom.html
+++ b/layouts/partials/head_custom.html
@@ -5,4 +5,15 @@
 .navbar-custom .avatar-container  .avatar-img {
   border-radius: 0;
 }
+.footnotes p {
+  display: flex;
+}
+.footnotes p a {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  white-space: nowrap;
+  flex: 1 0 90%;
+}
 </style>


### PR DESCRIPTION
The newly added link to the Linux Foundation blog in the footnote broke the layout on mobile. This ellipsizes it instead.