### PR TITLE
fix overall page layout

### DIFF
--- a/layouts/partials/head_custom.html
+++ b/layouts/partials/head_custom.html
@@ -9,11 +9,12 @@
   display: flex;
 }
 .footnotes p a {
-  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   display: inline-block;
   white-space: nowrap;
-  flex: 1 0 90%;
+}
+.footnotes p a:nth-child(1) {
+  max-width: 90%;
 }
 </style>


### PR DESCRIPTION
The previous attempt only looked okay in the footnote section. At the same time, it caused the page to still overflow. This now ensures that only the link expands to a 90% width, leaving the rest of the space for the back reference.